### PR TITLE
Fix incident detail page white screen on Vercel

### DIFF
--- a/api/incident.js
+++ b/api/incident.js
@@ -1,4 +1,4 @@
-const { mapFeature } = require('../../server/arcgis/mapFeature');
+const { mapFeature } = require('../server/arcgis/mapFeature');
 
 const ARCGIS_BASE =
   'https://spatialsolutions.hamilton.ca/webgis/rest/services/HFDIncidents/HFDIncidents/MapServer/0/query' +

--- a/react-ui/src/screens/Incident.jsx
+++ b/react-ui/src/screens/Incident.jsx
@@ -42,7 +42,7 @@ function ScreenIncident() {
     return null;
   }
 
-  const [streetAddress] = incident.location.address.split(',');
+  const [streetAddress] = (incident.location.address || 'Hamilton, ON').split(',');
   const locationText = incident.locationName ? incident.locationName.toLowerCase() : streetAddress;
 
   const { text: typeText } = incidentDefinitions[incident.category]

--- a/react-ui/src/store/modules/incidentLoaded.js
+++ b/react-ui/src/store/modules/incidentLoaded.js
@@ -5,7 +5,7 @@ import { processIncident } from './incidents';
 const PATH = window.location.port ? '//localhost:3001' : '';
 
 export const fetchIncident = createAsyncThunk('incident/fetch', async code => {
-  return fetch(`${PATH}/api/incident/${code}`, { method: 'GET' }).then(response => response.json());
+  return fetch(`${PATH}/api/incident?code=${code}`, { method: 'GET' }).then(response => response.json());
 });
 
 const incidentSlice = createSlice({

--- a/server/controllers/incidentController.js
+++ b/server/controllers/incidentController.js
@@ -5,6 +5,6 @@ exports.recent = async (req, res) => {
 };
 
 exports.incident = async (req, res) => {
-  const incident = getIncidentByCode(req.params.code);
+  const incident = getIncidentByCode(req.query.code);
   res.json(incident);
 };

--- a/server/routes.js
+++ b/server/routes.js
@@ -3,6 +3,6 @@ const router = express.Router();
 const incidentController = require('./controllers/incidentController');
 
 router.get('/recent', incidentController.recent);
-router.get('/incident/:code', incidentController.incident);
+router.get('/incident', incidentController.incident);
 
 module.exports = router;


### PR DESCRIPTION
## Summary

Fixed the white screen issue when loading individual incident pages (e.g., `/F26006528`). The Vercel serverless function at `api/incident/[code].js` wasn't being invoked due to the nested dynamic route pattern not being recognized. Changed to a flat file with query param to match Vercel's serverless routing expectations.

Also fixed a secondary bug where unmappable incidents (no location address) would crash with a null reference error.

## Changes

- Moved `api/incident/[code].js` → `api/incident.js` (flat file with query param)
- Updated all API calls to use query param: `/api/incident?code=X` instead of `/api/incident/X`
- Fixed null address handling in incident detail component

🤖 Generated with Claude